### PR TITLE
Update to latest release Alpine container (3.14.2)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.14
+FROM alpine:3.14.2
 
 ENV LANG=C.UTF-8
 


### PR DESCRIPTION
Believe it fixes:
 - CVE-2021-3711
 - CVE-2021-3712
 - CVE-2021-36159