### PR TITLE
[Dockerfile] add zlib package into container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,15 @@ ENV LANG=C.UTF-8
 
 # Here we install GNU libc (aka glibc) and set C.UTF-8 locale as default.
 
-RUN ALPINE_GLIBC_BASE_URL="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" && \
+RUN ZLIB_BASE_URL="https://github.com/anigkus/packages/raw/main/zstd" && \
+    ZLIB_BASE_URL_PACKAGE_FILENAME="zlib-1_1.2.12-1-x86_64.pkg.tar.gz"  && \
+    wget "$ZLIB_BASE_URL/$ZLIB_BASE_URL_PACKAGE_FILENAME" -O "/tmp/$ZLIB_BASE_URL_PACKAGE_FILENAME" && \
+    mkdir -p /tmp/libz && \
+    mkdir -p /usr/glibc-compat/lib && \
+    tar -xf "/tmp/$ZLIB_BASE_URL_PACKAGE_FILENAME" -C /tmp/libz/ && \
+    cp /tmp/libz/usr/lib/libz.so.1.2.12 /usr/glibc-compat/lib/  && \
+    rm -rf /tmp/libz "/tmp/$ZLIB_BASE_URL_PACKAGE_FILENAME" && \
+    ALPINE_GLIBC_BASE_URL="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" && \
     ALPINE_GLIBC_PACKAGE_VERSION="2.34-r0" && \
     ALPINE_GLIBC_BASE_PACKAGE_FILENAME="glibc-$ALPINE_GLIBC_PACKAGE_VERSION.apk" && \
     ALPINE_GLIBC_BIN_PACKAGE_FILENAME="glibc-bin-$ALPINE_GLIBC_PACKAGE_VERSION.apk" && \


### PR DESCRIPTION
# update explain ...
  I'm use master branch dockerfile to build base image, dockerfile no problem. But when I build the oracle jdk 11.0.13 version based on the alpine-glibc base image,the following exception occurs. This exception is mainly due to the missing libc.so file. 

## Dockefile on master branch
 Below base image [alpine-glibc:alpine-3.5_glibc-2.34-r0] build for https://github.com/Docker-Hub-frolvlad/docker-alpine-glibc/blob/master/Dockerfile 

```
FROM alpine-glibc:alpine-3.5_glibc-2.34-r0

# JDK download , https://www.oracle.com/java/technologies/javase/jdk11-archive-downloads.html
ADD jdk-11.0.13_linux-x64_bin.tar.gz /usr/java/jdk/

ENV LANG=C.UTF-8
ENV JAVA_VERSION=11.0.13
ENV JAVA_HOME /usr/java/jdk/jdk-11.0.13
ENV PATH ${PATH}:${JAVA_HOME}/bin

WORKDIR /opt
```

## An error occurred
```  
➜  ~ docker run  --name anigkus-oracle-jdk  -it anigkus/oracle-jdk:11.0.13
/opt # java -version
java version "11.0.13" 2021-10-19 LTS
Java(TM) SE Runtime Environment 18.9 (build 11.0.13+10-LTS-370)
Java HotSpot(TM) 64-Bit Server VM 18.9 (build 11.0.13+10-LTS-370, mixed mode)
[thread 14 also had an error]
#
# A fatal error has been detected by the Java Runtime Environment:
#
#  SIGSEGV (0xb) at pc=0x00007fde5740df35, pid=8, tid=13
#
# JRE version: Java(TM) SE Runtime Environment 18.9 (11.0.13+10) (build 11.0.13+10-LTS-370)
# Java VM: Java HotSpot(TM) 64-Bit Server VM 18.9 (11.0.13+10-LTS-370, mixed mode, tiered, compressed oops, g1 gc, linux-amd64)
# Problematic frame:
# C  [libc.so.6+0x132f35]
#
# No core dump will be written. Core dumps have been disabled. To enable core dumping, try "ulimit -c unlimited" before starting Java again
#
[thread 11 also had an error]
[thread 15 also had an error]
# An error report file with more information is saved as:
# /opt/hs_err_pid8.log
[thread 23 also had an error]
[thread 9 also had an error]
#
# If you would like to submit a bug report, please visit:
#   https://bugreport.java.com/bugreport/crash.jsp
#
Aborted
/opt # 
```

##  Updated Dockefile.
```
FROM alpine:3.15

ENV LANG=C.UTF-8

# Here we install GNU libc (aka glibc) and set C.UTF-8 locale as default.

RUN ZLIB_BASE_URL="https://github.com/anigkus/packages/raw/main/zstd" && \
    ZLIB_BASE_URL_PACKAGE_FILENAME="zlib-1_1.2.12-1-x86_64.pkg.tar.gz"  && \
    wget "$ZLIB_BASE_URL/$ZLIB_BASE_URL_PACKAGE_FILENAME" -O "/tmp/$ZLIB_BASE_URL_PACKAGE_FILENAME" && \
    mkdir -p /tmp/libz && \
    mkdir -p /usr/glibc-compat/lib && \
    tar -xf "/tmp/$ZLIB_BASE_URL_PACKAGE_FILENAME" -C /tmp/libz/ && \
    cp /tmp/libz/usr/lib/libz.so.1.2.12 /usr/glibc-compat/lib/  && \
    rm -rf /tmp/libz "/tmp/$ZLIB_BASE_URL_PACKAGE_FILENAME" && \ 
    ALPINE_GLIBC_BASE_URL="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" && \
    ALPINE_GLIBC_PACKAGE_VERSION="2.34-r0" && \
    ALPINE_GLIBC_BASE_PACKAGE_FILENAME="glibc-$ALPINE_GLIBC_PACKAGE_VERSION.apk" && \
    ALPINE_GLIBC_BIN_PACKAGE_FILENAME="glibc-bin-$ALPINE_GLIBC_PACKAGE_VERSION.apk" && \
    ALPINE_GLIBC_I18N_PACKAGE_FILENAME="glibc-i18n-$ALPINE_GLIBC_PACKAGE_VERSION.apk" && \
    apk add --no-cache --virtual=.build-dependencies wget ca-certificates && \
    echo \
        "-----BEGIN PUBLIC KEY-----\
        MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApZ2u1KJKUu/fW4A25y9m\
        y70AGEa/J3Wi5ibNVGNn1gT1r0VfgeWd0pUybS4UmcHdiNzxJPgoWQhV2SSW1JYu\
        tOqKZF5QSN6X937PTUpNBjUvLtTQ1ve1fp39uf/lEXPpFpOPL88LKnDBgbh7wkCp\
        m2KzLVGChf83MS0ShL6G9EQIAUxLm99VpgRjwqTQ/KfzGtpke1wqws4au0Ab4qPY\
        KXvMLSPLUp7cfulWvhmZSegr5AdhNw5KNizPqCJT8ZrGvgHypXyiFvvAH5YRtSsc\
        Zvo9GI2e2MaZyo9/lvb+LbLEJZKEQckqRj4P26gmASrZEPStwc+yqy1ShHLA0j6m\
        1QIDAQAB\
        -----END PUBLIC KEY-----" | sed 's/   */\n/g' > "/etc/apk/keys/sgerrand.rsa.pub" && \
    wget \
        "$ALPINE_GLIBC_BASE_URL/$ALPINE_GLIBC_PACKAGE_VERSION/$ALPINE_GLIBC_BASE_PACKAGE_FILENAME" \
        "$ALPINE_GLIBC_BASE_URL/$ALPINE_GLIBC_PACKAGE_VERSION/$ALPINE_GLIBC_BIN_PACKAGE_FILENAME" \
        "$ALPINE_GLIBC_BASE_URL/$ALPINE_GLIBC_PACKAGE_VERSION/$ALPINE_GLIBC_I18N_PACKAGE_FILENAME" && \
    apk add --no-cache \
        "$ALPINE_GLIBC_BASE_PACKAGE_FILENAME" \
        "$ALPINE_GLIBC_BIN_PACKAGE_FILENAME" \
        "$ALPINE_GLIBC_I18N_PACKAGE_FILENAME" && \
    \
    rm "/etc/apk/keys/sgerrand.rsa.pub" && \
    (/usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 "$LANG" || true) && \
    echo "export LANG=$LANG" > /etc/profile.d/locale.sh && \
    \
    apk del glibc-i18n && \
    \
    rm "/root/.wget-hsts" && \
    apk del .build-dependencies && \
    rm \
        "$ALPINE_GLIBC_BASE_PACKAGE_FILENAME" \
        "$ALPINE_GLIBC_BIN_PACKAGE_FILENAME" \
        "$ALPINE_GLIBC_I18N_PACKAGE_FILENAME"
```

## Now normal
```
➜  ~ docker run  --name anigkus-oracle-jdk  -it anigkus/oracle-jdk:11.0.13
/opt # java -version
java version "11.0.13" 2021-10-19 LTS
Java(TM) SE Runtime Environment 18.9 (build 11.0.13+10-LTS-370)
Java HotSpot(TM) 64-Bit Server VM 18.9 (build 11.0.13+10-LTS-370, mixed mode)
/opt #
```

## Have you considered building the zlib package? I'm commit a patch.
```
ZLIB_BASE_URL="https://github.com/anigkus/packages/raw/main/zstd" && \
    ZLIB_BASE_URL_PACKAGE_FILENAME="zlib-1_1.2.12-1-x86_64.pkg.tar.gz"  && \
    wget "$ZLIB_BASE_URL/$ZLIB_BASE_URL_PACKAGE_FILENAME" -O "/tmp/$ZLIB_BASE_URL_PACKAGE_FILENAME" && \
    mkdir -p /tmp/libz && \
    mkdir -p /usr/glibc-compat/lib && \
    tar -xf "/tmp/$ZLIB_BASE_URL_PACKAGE_FILENAME" -C /tmp/libz/ && \
    cp /tmp/libz/usr/lib/libz.so.1.2.12 /usr/glibc-compat/lib/  && \
    rm -rf /tmp/libz "/tmp/$ZLIB_BASE_URL_PACKAGE_FILENAME"
```